### PR TITLE
explicitly set supports_statement_cache

### DIFF
--- a/sqlalchemy_databricks/_dialect.py
+++ b/sqlalchemy_databricks/_dialect.py
@@ -10,6 +10,7 @@ from sqlalchemy import util
 class DatabricksDialect(HiveDialect):
     name = "databricks"
     driver = "connector"  # databricks-sql-connector
+    supports_statement_cache = False  # can this be True?
 
     @classmethod
     def dbapi(cls):


### PR DESCRIPTION
Closes #3, although I don't know whether this can be set to True. Setting to False for now to eliminate the warning.