### PR TITLE
Alembic Support

### DIFF
--- a/sqlalchemy_databricks/_dialect.py
+++ b/sqlalchemy_databricks/_dialect.py
@@ -21,10 +21,19 @@ else:
         __dialect__ = 'databricks'
 
 
+class DatabricksDDLCompiler(compiler.DDLCompiler):
+    def visit_primary_key_constraint(self, constraint, **kw):
+        """Override because Databricks doesn't support primary keys"""
+
+        return ''
+
+
 class DatabricksDialect(HiveDialect):
     name = "databricks"
     driver = "connector"  # databricks-sql-connector
     supports_statement_cache = False  # can this be True?
+
+    ddl_compiler = DatabricksDDLCompiler
 
     @classmethod
     def dbapi(cls):
@@ -91,10 +100,3 @@ class DatabricksDialect(HiveDialect):
                 }
             )
         return result
-
-
-class DatabricksDDLCompiler(compiler.DDLCompiler):
-    def visit_primary_key_constraint(self, constraint, **kw):
-        """Override because Databricks doesn't support primary keys"""
-
-        return ''

--- a/sqlalchemy_databricks/_dialect.py
+++ b/sqlalchemy_databricks/_dialect.py
@@ -59,7 +59,7 @@ class DatabricksDialect(HiveDialect):
         return [row[1] for row in connection.execute(query)]
 
     def has_table(self, connection, table_name, schema=None):
-        # override because Databricks raises a different error when no table exists
+        """override because Databricks raises a different error when no table exists"""
         try:
             self._get_table_columns(connection, table_name, schema)
             return True

--- a/sqlalchemy_databricks/_dialect.py
+++ b/sqlalchemy_databricks/_dialect.py
@@ -3,7 +3,6 @@ import re
 from databricks import sql
 from pyhive.sqlalchemy_hive import HiveDialect
 from pyhive.sqlalchemy_hive import _type_map
-import sqlalchemy
 from sqlalchemy import exc
 from sqlalchemy import types
 from sqlalchemy import util

--- a/tests/test_dialect.py
+++ b/tests/test_dialect.py
@@ -9,3 +9,34 @@ def test_dialect(host, http_path, token):
     )
     tables = inspect(engine).get_table_names()
     print(tables)
+
+
+def test_has_table(host, http_path, token):
+    engine = create_engine(
+        f"databricks+connector://token:{token}@{host}:443/default",
+        connect_args={"http_path": f"{http_path}"},
+    )
+
+    engine.dialect.has_table(engine, 'table_name_that_should_not_exist')
+
+
+def test_create_table_with_primary_key():
+    def raise_if_primary_key(sql, *multiparams, **params):
+        ddl_statement =  str(sql.compile(dialect=engine.dialect))
+        if 'primary' in ddl_statement.lower():
+            raise ValueError(f'{ddl_statement=}')
+
+    engine = create_mock_engine(
+        f"databricks+connector://token:test@test:443/default",
+        raise_if_primary_key
+    )
+
+    metadata_obj = MetaData()
+
+    test = Table(
+        'test',
+        metadata_obj,
+        Column('test_id', Integer, primary_key=True)
+    )
+
+    metadata_obj.create_all(engine)


### PR DESCRIPTION
Overrides two methods from the HiveDialect:
- `has_table`: Databricks raises a different exception if a table doesn't exist
- `visit_primary_key_constraint`: Databricks doesn't support PK when creating tables