### PR TITLE
add custom type compiler, fix data type DATE

### DIFF
--- a/sqlalchemy_databricks/_dialect.py
+++ b/sqlalchemy_databricks/_dialect.py
@@ -5,12 +5,14 @@ from pyhive.sqlalchemy_hive import HiveDialect
 from pyhive.sqlalchemy_hive import _type_map
 from sqlalchemy import types
 from sqlalchemy import util
+from sqlalchemy_databricks._type import DatabricksTypeCompiler
 
 
 class DatabricksDialect(HiveDialect):
     name = "databricks"
     driver = "connector"  # databricks-sql-connector
     supports_statement_cache = False  # can this be True?
+    type_compiler = DatabricksTypeCompiler
 
     @classmethod
     def dbapi(cls):

--- a/sqlalchemy_databricks/_type.py
+++ b/sqlalchemy_databricks/_type.py
@@ -1,0 +1,8 @@
+from pyhive.sqlalchemy_hive import HiveTypeCompiler
+
+
+class DatabricksTypeCompiler(HiveTypeCompiler):
+    def visit_DATE(self, type_):
+        # Woraround because pyhive uses TIMESTAMP instead of DATE.
+        # See as well: https://github.com/dropbox/PyHive/issues/139
+        return 'DATE'


### PR DESCRIPTION
PyHive mappes the data type `DATE` to a old data type `TIMESTAMP` which is a quite old way of mapping `Date` types. Since databricks have been launched after Hive 0.12 I would strongly recommend to fix the data type mapping to DATE in the SQLAlchemy implementation for databricks.

See also: https://github.com/dropbox/PyHive/issues/139